### PR TITLE
Controle de acesso por usuário nos avistamentos

### DIFF
--- a/src/app/avistamentos/page.tsx
+++ b/src/app/avistamentos/page.tsx
@@ -6,10 +6,16 @@ import { Avistamento } from "@/types/avistamento";
 import AvistamentoCard from "@/components/AvistamentoCard";
 import AvistamentoForm from "@/components/AvistamentoForm";
 
+interface User {
+  id: number;
+  tipo_usuario: string;
+}
+
 export default function AvistamentosPage() {
   const [avistamentos, setAvistamentos] = useState<Avistamento[]>([]);
   const [loading, setLoading] = useState(true);
   const [editData, setEditData] = useState<Avistamento | undefined>(undefined);
+  const [user, setUser] = useState<User | null>(null);
 
   const fetchAvistamentos = async () => {
     try {
@@ -25,23 +31,25 @@ export default function AvistamentosPage() {
 
   useEffect(() => {
     fetchAvistamentos();
+    const stored = localStorage.getItem("user");
+    if (stored) setUser(JSON.parse(stored));
   }, []);
 
   return (
     <div className="p-4 space-y-6">
       <h1 className="text-2xl font-bold">Avistamentos</h1>
 
-      {/* Formulário: modo criação ou edição */}
-      <AvistamentoForm
-        editData={editData}
-        onSuccess={() => {
-          fetchAvistamentos();
-          setEditData(undefined);
-        }}
-        onCancelEdit={() => setEditData(undefined)}
-      />
+      {user && (
+        <AvistamentoForm
+          editData={editData}
+          onSuccess={() => {
+            fetchAvistamentos();
+            setEditData(undefined);
+          }}
+          onCancelEdit={() => setEditData(undefined)}
+        />
+      )}
 
-      {/* Lista de Avistamentos */}
       {loading ? (
         <p>Carregando avistamentos...</p>
       ) : avistamentos.length === 0 ? (
@@ -54,6 +62,7 @@ export default function AvistamentosPage() {
               avistamento={a}
               onDeleted={fetchAvistamentos}
               onEdit={(item) => setEditData(item)}
+              user={user}
             />
           ))}
         </div>

--- a/src/components/AvistamentoCard.tsx
+++ b/src/components/AvistamentoCard.tsx
@@ -8,9 +8,13 @@ interface Props {
   avistamento: Avistamento;
   onDeleted?: () => void;
   onEdit: (avistamento: Avistamento) => void;
+  user: {
+    id: number;
+    tipo_usuario: string;
+  } | null;
 }
 
-export default function AvistamentoCard({ avistamento, onDeleted, onEdit }: Props) {
+export default function AvistamentoCard({ avistamento, onDeleted, onEdit, user }: Props) {
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
 
@@ -27,6 +31,8 @@ export default function AvistamentoCard({ avistamento, onDeleted, onEdit }: Prop
       setLoading(false);
     }
   };
+
+  const isOwner = user?.id === avistamento.userId || user?.tipo_usuario === "ADMIN";
 
   return (
     <div className="bg-white border rounded-lg shadow p-4 space-y-2">
@@ -55,21 +61,23 @@ export default function AvistamentoCard({ avistamento, onDeleted, onEdit }: Prop
         <p><strong>Contato:</strong> {avistamento.contatoInformante}</p>
       )}
 
-      <div className="flex gap-2 mt-2">
-        <button
-          onClick={() => onEdit(avistamento)}
-          className="bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600"
-        >
-          ✏️ Editar
-        </button>
-        <button
-          onClick={handleDelete}
-          disabled={loading}
-          className="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700"
-        >
-          {loading ? "Excluindo..." : "🗑️ Excluir"}
-        </button>
-      </div>
+      {isOwner && (
+        <div className="flex gap-2 mt-2">
+          <button
+            onClick={() => onEdit(avistamento)}
+            className="bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600"
+          >
+            ✏️ Editar
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={loading}
+            className="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700"
+          >
+            {loading ? "Excluindo..." : "🗑️ Excluir"}
+          </button>
+        </div>
+      )}
 
       {errorMsg && <p className="text-red-500 text-sm">{errorMsg}</p>}
     </div>

--- a/src/services/avistamentos.ts
+++ b/src/services/avistamentos.ts
@@ -8,15 +8,16 @@ export async function getAllAvistamentos(): Promise<Avistamento[]> {
   return response.data.avistamentos;
 }
 
-export async function createAvistamento(data: Omit<Avistamento, "id">): Promise<Avistamento> {
+export async function createAvistamento(data: Omit<Avistamento, "id" | "userId">): Promise<Avistamento> {
   const response = await api.post("/avistamento/cadastrar", data);
   return response.data.avistamento;
 }
 
-export async function updateAvistamento(id: number, data: Omit<Avistamento, "id">): Promise<Avistamento> {
+export async function updateAvistamento(id: number, data: Omit<Avistamento, "id" | "userId">):Promise<Avistamento> {
   const response = await api.patch(`/avistamento/atualizar/${id}`, data);
   return response.data.avistamento;
 }
+
 
 export async function deleteAvistamento(id: number): Promise<void> {
   await api.delete(`/avistamento/deletar/${id}`);

--- a/src/types/avistamento.ts
+++ b/src/types/avistamento.ts
@@ -7,7 +7,7 @@ export interface Avistamento {
   longitude?: number;
   nomeInformante?: string;
   contatoInformante?: string;
-  dataHora?: string;
+  userId: number;
   dataCadastro?: string;
   dataAtualizacao?: string;
 }


### PR DESCRIPTION
- Adição do `userId` na tipagem dos avistamentos
- Ajustes nas funções de criação e edição para não enviar `userId` no body
- Exibição dos botões de editar e excluir apenas para o usuário dono do dado ou administradores
- Carregamento do usuário logado via localStorage para controle visual
